### PR TITLE
[WIP] add precommit hook for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos: 
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks: 
+    - id: black
+      language_version: python3.6


### PR DESCRIPTION
This adds `black` as a precommit hook to code. I'm not sure how yet to configure this, since we want it to look *inside* of jupyter notebook files first. But, this is th first step, following:

https://black.readthedocs.io/en/stable/version_control_integration.html