### PR TITLE
add google analytics to the book

### DIFF
--- a/infrastructure/booksite/_config.yml
+++ b/infrastructure/booksite/_config.yml
@@ -135,5 +135,9 @@ plugins:
   - jekyll-redirect-from
   - jekyll-scholar
 
+google_analytics:
+    mytrackingcode: UA-25436886-4
+
+
 # Jupyter Book version - DO NOT CHANGE THIS. It is generated when a new book is created
 jupyter_book_version: INSERT


### PR DESCRIPTION
This adds the google analytics to the booksite config. I'll need someone who can actually run the docker to rebuild the site and merge this, since the docker still runs into permissions issues with our current makefile. And, we can't run the `build.sh` separately because it hardcodes paths setup by the docker. 